### PR TITLE
Revert red and blue coefficient constants

### DIFF
--- a/Resources/Shaders.hlsl
+++ b/Resources/Shaders.hlsl
@@ -193,18 +193,8 @@ Undistort_PS_IN Undistort_VS(Undistort_VS_IN input)
 
 float4 Undistort_PS(Undistort_PS_IN input) : SV_Target
 {	
-	float ir = 1.0 / 0.9959283065186691; // 1.50917f / 1.51534f;
-	float ib = 1.0 / 1.001029471933691; //1.51690f / 1.51534f;
-
-	//float scale = 1.0 + GrowToUndistort;	
-	float rscale = ir + GrowToUndistort;
-	float gscale = 1.0f + GrowToUndistort;
-	float bscale = ib + GrowToUndistort;
-
-
-
+	float scale = 1.0f + GrowToUndistort;
 	float aspect = Aspect;
-
 	float2 UV = (input.uv * 2) - 1;	//convert [0;1] to [-1;1]	
 	UV.y *= aspect;
 	
@@ -213,18 +203,17 @@ float4 Undistort_PS(Undistort_PS_IN input) : SV_Target
 	float2 ruv = UV - center;
 	float rr2 = dot(ruv, ruv);		
 	float rk = 1.0 / (RedCoeffs.w + RedCoeffs.x * rr2 + RedCoeffs.y * rr2 * rr2 + RedCoeffs.z * rr2 * rr2 * rr2);	
-	ruv = (ruv * rk + center) / rscale;
+	ruv = (ruv * rk + center) / scale;
 	ruv.y /= aspect;
 	ruv = (ruv + 1) / 2; //convert [-1;1] back to [0;1]
 	float R = diffuseTexture.Sample(diffuseSampler, ruv).r;
-		
 	
 	center = GreenCenter.xy;
 	center.y *= aspect;
 	float2 guv = UV - center;	
 	float gr2 = dot(guv, guv);
 	float gk = 1.0 / (GreenCoeffs.w + GreenCoeffs.x * gr2 + GreenCoeffs.y * gr2 * gr2 + GreenCoeffs.z * gr2 * gr2 * gr2);
-	guv = (guv * gk + center) / gscale;
+	guv = (guv * gk + center) / scale;
 	guv.y /= aspect;
 	guv = (guv + 1) / 2;
 	float G = diffuseTexture.Sample(diffuseSampler, guv).g;
@@ -234,7 +223,7 @@ float4 Undistort_PS(Undistort_PS_IN input) : SV_Target
 	float2 buv = UV - center;		
 	float br2 = dot(buv, buv);
 	float bk = 1.0 / (BlueCoeffs.w + BlueCoeffs.x * br2 + BlueCoeffs.y * br2 * br2 + BlueCoeffs.z * br2 * br2 * br2);	
-	buv = (buv * bk + center) / bscale;
+	buv = (buv * bk + center) / scale;
 	buv.y /= aspect;
 	buv = (buv + 1) / 2;
 	float B = diffuseTexture.Sample(diffuseSampler, buv).b;


### PR DESCRIPTION
Fixes https://github.com/sencercoltu/steamvr-undistort/issues/9.

Reverts the coefficient constants introduced in https://github.com/sencercoltu/steamvr-undistort/commit/a49c7c30a15e09a9a7a7b0144af87c4d2189e502.  They added some small corrections so the pixel shader would match the original view without distortion adjustments.

However, it appears that the red and blue distortion issues was fixed in SteamVR, and the compensation actually adds distortion with current software.  I'm not sure what version introduced the changes, but I noticed the distortion being off in Undistort on 02-02-2020.  This issue is reproducible with SteamVR 1.9.16.

A little background of this issue can be found in #9.  From @synthead (me) in https://github.com/sencercoltu/steamvr-undistort/issues/9#issue-560794135:

> When I load the utility and make no changes, I am able to observe different distortion compensation between the original view and the corrected preview. For example, I am able to get all the "c" settings dialed in perfectly in the preview, but after writing and rebooting SteamVR, I am able to see reds and blues on the edges of objects in the mids and edges of my vision.
> 
> On about Feb 2nd (2020), I noticed that the distortion was slightly off. Maybe it has to do with a SteamVR update? Perhaps reprojection plays into it, somehow? I thought it was from physically shifting the lenses from cleaning them often, but after finding that the distortion preview wasn't identical, I wonder if it's a software thing. I remember the preview being exactly correct in the past.

From @sencercoltu in https://github.com/sencercoltu/steamvr-undistort/issues/9#issuecomment-582931255:

> Hi, nothing has changed on the software side.
> Previously there was a slight shift in channels, after adding a wavelength coefficient constant to red and blue channels coefficients inside the shader, the shift was gone. Maybe it's not needed anymore after the Feb update. Since I switched to Pimax, I won't be able to check the issue easily soon.